### PR TITLE
Fixed Delay Calculation

### DIFF
--- a/app/code/community/Zend/Db/Statement/Pdo.php
+++ b/app/code/community/Zend/Db/Statement/Pdo.php
@@ -276,7 +276,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
      */
     public static function getDelay($tries){
         $power = Mage::registry('system/deadlock/delaypower');
-        return (int) pow($power, $tries);
+        return (int) pow($tries, $power);
     }
 
     /**


### PR DESCRIPTION
- Delay calculation was backwards, resulting in a 32 second delay on 5th retry instead of the documented 25 seconds
